### PR TITLE
Add unimodal texture demo scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Wrapper for α→β transformation in reverse:
 - Also delegates to `parentToProductTexture`
 - Follows similar output and folder structure
 
+### `simulateUniModalBeta2AlphaTexture.m` & `simulateUniModalAlpha2BetaTexture.m`
+
+Self-contained examples that build an ideal single-orientation texture and
+invoke `parentToProductTexture` for several `sel` values. They write all
+generated ODFs and pole figures to `results/simulatedTextures/` and are a
+handy way to confirm the toolkit is working without external data files.
+Running either script is an easy check that the transformation functions and
+your MTEX setup are behaving correctly. They also validate that your MATLAB
+version is at least R2020a and that MTEX 5.4.0 is on the path.
+
 ---
 
 ## Supporting Functions

--- a/alpha2BetaTexture.m
+++ b/alpha2BetaTexture.m
@@ -9,6 +9,8 @@
 clear all
 close all
 
+checkEnvironment();
+
 debug = true;
 consider_PreExistingBeta = true;
 
@@ -50,7 +52,7 @@ else
 end
 
 %======================= Start Batch Processing Loop ======================
-fprintf('\n=======  Batch \u03b1\u2192\u03b2 ODF conversion  =======\n');
+fprintf('\n=======  Batch α→β ODF conversion  =======\n');
 ticGlobal = tic;
 procCount = 0;
 

--- a/beta2AlphaTexture.m
+++ b/beta2AlphaTexture.m
@@ -9,6 +9,8 @@
 clear all
 close all
 
+checkEnvironment();
+
 debug = true;
 consider_PreExistingAlpha = true;
 
@@ -60,7 +62,7 @@ else
 end
 
 %======================= Start Batch Processing Loop ======================
-fprintf('\n=======  Batch \u03b2\u2192\u03b1 ODF conversion  =======\n');
+fprintf('\n=======  Batch β→α ODF conversion  =======\n');
 ticGlobal = tic;
 procCount = 0;
 

--- a/local_functions.m
+++ b/local_functions.m
@@ -73,3 +73,22 @@ function plotAndSaveODF(odf, hA, outFilePath, sel, alphaFrac, dataSetName)
     print(fig, [outFilePath '.png'], '-dpng', '-r300');
     close(fig);
 end
+
+function checkEnvironment()
+% checkEnvironment - Ensures MATLAB and MTEX versions meet requirements.
+    if verLessThan('matlab','9.8')
+        error('MATLAB 9.8 (R2020a) or newer is required.');
+    end
+    mtexVer = '';
+    if exist('mtex_version','file') == 2
+        mtexVer = char(mtex_version);
+    elseif exist('mtexVersion','file') == 2
+        mtexVer = char(mtexVersion);
+    end
+    if isempty(mtexVer)
+        error('Unable to determine MTEX version.');
+    end
+    if ~strcmp(strtrim(mtexVer),'5.4.0')
+        error('MTEX version 5.4.0 is required. Detected %s.', mtexVer);
+    end
+end

--- a/parentToProductTexture.m
+++ b/parentToProductTexture.m
@@ -37,6 +37,8 @@ function [odfProduct, report] = parentToProductTexture(inputTextureFile, parentP
 %       'PreTextureFile','alpha/odf.txt','PreFraction',0.1,
 %       'OutputDir','results');
 
+checkEnvironment();
+
 % ---- parse inputs -------------------------------------------------------
 p = inputParser;
 addRequired(p,'inputTextureFile',@(x)ischar(x)||isstring(x));

--- a/simulateUniModalAlpha2BetaTexture.m
+++ b/simulateUniModalAlpha2BetaTexture.m
@@ -1,0 +1,65 @@
+% simulateUniModalAlpha2BetaTexture.m
+% Demonstrate the use of parentToProductTexture for a unimodal α→β transformation.
+% This script builds ideal α and β unimodal textures, saves them into tmp/
+% as simulatedAlpha.odf and simulatedBeta.odf, then executes the reverse
+% transformation for a set of selection (sel) values. Pole figures are
+% stored under results/simulatedTextures/.
+
+clear; clc; close all;
+
+checkEnvironment();
+
+fprintf('\n=== Simulate α→β Transformation on Unimodal Data ===\n');
+
+%% setup directories
+rootDir = pwd;
+tmpDir  = fullfile(rootDir,'tmp');
+outDir  = fullfile(rootDir,'results','simulatedTextures');
+if ~exist(tmpDir,'dir'), mkdir(tmpDir); end
+if ~exist(outDir,'dir'), mkdir(outDir); end
+
+%% crystal and specimen symmetries
+csA = crystalSymmetry('6/mmm',[2.951 2.951 4.684],'mineral','α-Ti');
+csB = crystalSymmetry('m-3m',[3.32 3.32 3.32],'mineral','β-Ti');
+ss  = specimenSymmetry('1');
+
+%% create unimodal parent and pre-existing product textures
+alphaFile = fullfile(tmpDir,'simulatedAlpha.odf');
+betaFile  = fullfile(tmpDir,'simulatedBeta.odf');
+
+g0A = orientation('Euler',0*degree,0*degree,0*degree,csA,ss);
+odfA = unimodalODF(g0A,15*degree);
+export(odfA,alphaFile,'Bunge');
+fprintf('Saved parent α ODF to %s\n',alphaFile);
+
+g0B = orientation('Euler',0*degree,0*degree,0*degree,csB,ss);
+odfBpre = unimodalODF(g0B,15*degree);
+export(odfBpre,betaFile,'Bunge');
+fprintf('Saved pre-existing β ODF to %s\n',betaFile);
+
+%% plot initial α (0001) pole figure
+fig = figure('Visible','off');
+plotPDF(odfA,Miller({0,0,0,1},csA),'contourf','resolution',5*degree,'antipodal');
+mtexColorbar;
+print(fig,fullfile(outDir,'alpha_0001_pf.png'),'-dpng','-r300');
+close(fig);
+fprintf('Saved parent α (0001) pole figure.\n');
+
+%% perform transformation for various sel values
+selList = 0.1:0.2:1.0;
+for sel = selList
+    fprintf('\n--- Running parentToProductTexture with sel = %.2f ---\n',sel);
+    [odfBeta,~] = parentToProductTexture(alphaFile,'alpha','beta', ...
+        'Sel',sel,'PreTransformed',true,'PreTextureFile',betaFile, ...
+        'PreFraction',0.2,'OutputDir',outDir,'DataSetName','unimodal_demo');
+
+    fig = figure('Visible','off');
+    plotPDF(odfBeta,Miller(1,1,0,csB),'contourf','resolution',5*degree,'antipodal');
+    mtexColorbar;
+    pfName = sprintf('beta_110_pf_sel_%0.2f.png',sel);
+    print(fig,fullfile(outDir,pfName),'-dpng','-r300');
+    close(fig);
+    fprintf('Saved product β (110) pole figure: %s\n',pfName);
+end
+
+fprintf('\nAll α→β simulations complete. Results in %s\n',outDir);

--- a/simulateUniModalBeta2AlphaTexture.m
+++ b/simulateUniModalBeta2AlphaTexture.m
@@ -1,0 +1,65 @@
+% simulateUniModalBeta2AlphaTexture.m
+% Demonstrate the use of parentToProductTexture for a unimodal β→α transformation.
+% This script builds ideal unimodal β and α textures, saves them to tmp/
+% as simulatedBeta.odf and simulatedAlpha.odf, then performs the forward
+% transformation for different selection (sel) values. All generated pole
+% figures are saved in results/simulatedTextures/.
+
+clear; clc; close all;
+
+checkEnvironment();
+
+fprintf('\n=== Simulate β→α Transformation on Unimodal Data ===\n');
+
+%% setup directories
+rootDir = pwd;
+tmpDir  = fullfile(rootDir,'tmp');
+outDir  = fullfile(rootDir,'results','simulatedTextures');
+if ~exist(tmpDir,'dir'), mkdir(tmpDir); end
+if ~exist(outDir,'dir'), mkdir(outDir); end
+
+%% crystal and specimen symmetries
+csB = crystalSymmetry('m-3m',[3.32 3.32 3.32],'mineral','β-Ti');
+csA = crystalSymmetry('6/mmm',[2.951 2.951 4.684],'mineral','α-Ti');
+ss  = specimenSymmetry('1');
+
+%% create unimodal parent and pre-existing product textures
+betaFile  = fullfile(tmpDir,'simulatedBeta.odf');
+alphaFile = fullfile(tmpDir,'simulatedAlpha.odf');
+
+g0B = orientation('Euler',0*degree,0*degree,0*degree,csB,ss);
+odfB = unimodalODF(g0B,15*degree);
+export(odfB,betaFile,'Bunge');
+fprintf('Saved parent β ODF to %s\n',betaFile);
+
+g0A = orientation('Euler',0*degree,0*degree,0*degree,csA,ss);
+odfApre = unimodalODF(g0A,15*degree);
+export(odfApre,alphaFile,'Bunge');
+fprintf('Saved pre-existing α ODF to %s\n',alphaFile);
+
+%% plot initial β (110) pole figure
+fig = figure('Visible','off');
+plotPDF(odfB,Miller(1,1,0,csB),'contourf','resolution',5*degree,'antipodal');
+mtexColorbar;
+print(fig,fullfile(outDir,'beta_110_pf.png'),'-dpng','-r300');
+close(fig);
+fprintf('Saved parent β (110) pole figure.\n');
+
+%% perform transformation for various sel values
+selList = 0.1:0.2:1.0;
+for sel = selList
+    fprintf('\n--- Running parentToProductTexture with sel = %.2f ---\n',sel);
+    [odfAlpha,~] = parentToProductTexture(betaFile,'beta','alpha', ...
+        'Sel',sel,'PreTransformed',true,'PreTextureFile',alphaFile, ...
+        'PreFraction',0.2,'OutputDir',outDir,'DataSetName','unimodal_demo');
+
+    fig = figure('Visible','off');
+    plotPDF(odfAlpha,Miller({0,0,0,1},csA),'contourf','resolution',5*degree,'antipodal');
+    mtexColorbar;
+    pfName = sprintf('alpha_0001_pf_sel_%0.2f.png',sel);
+    print(fig,fullfile(outDir,pfName),'-dpng','-r300');
+    close(fig);
+    fprintf('Saved product α (0001) pole figure: %s\n',pfName);
+end
+
+fprintf('\nAll β→α simulations complete. Results in %s\n',outDir);

--- a/test_mtexPoleFigures.m
+++ b/test_mtexPoleFigures.m
@@ -1,5 +1,6 @@
 %% test_plotPDF_unimodal.m  —  minimal MTEX sanity check
 % ------------------------------------------------------
+checkEnvironment();
 % 1.  Quick “is MTEX on the path?” test
 try
     mtexRoot = fileparts(which('quaternion'));


### PR DESCRIPTION
## Summary
- create ideal unimodal textures in the demo scripts using `unimodalODF`
- replace escaped Greek letters with actual symbols
- mention the demos in the README as quick validation examples
- ensure MATLAB and MTEX versions are checked in all top-level scripts

## Testing
- `matlab -batch "exit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d0f9286c832482bfce2bbf933a65